### PR TITLE
abstract-blob-store 3.3.2 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "node test.js"
   },
   "dependencies": {
-    "debug": "^2.0.0",
+    "debug": "^3.1.0",
     "mime-types": "^2.0.0",
     "s3-download-stream": "0.0.5",
     "s3-stream-upload": "^2.0.1"
@@ -25,6 +25,6 @@
   "devDependencies": {
     "abstract-blob-store": "^3.3.2",
     "aws-sdk": "^2.0.15",
-    "tape": "^2.14.0"
+    "tape": "^4.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "s3-stream-upload": "^2.0.1"
   },
   "devDependencies": {
-    "abstract-blob-store": "^2.1.0",
+    "abstract-blob-store": "^3.3.2",
     "aws-sdk": "^2.0.15",
     "tape": "^2.14.0"
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "blob"
   ],
   "version": "2.0.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/jb55/s3-blob-store.git"


### PR DESCRIPTION
Adds support for the `.notFound` property on errors.

Depends on https://github.com/jb55/s3-download-stream/pull/5