### PR TITLE
Use params for remove method

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,8 +99,17 @@ S3BlobStore.prototype.createWriteStream = function (opts, s3opts, done) {
  * @param {function(Error)} done callback
  */
 S3BlobStore.prototype.remove = function (opts, done) {
-  var key = typeof opts === 'string' ? opts : opts.key;
-  this.s3.deleteObject({ Bucket: this.bucket, Key: key }, done);
+  var params = {}
+  if (typeof opts === 'string') {
+    params.Key = opts;
+  } else {
+    opts = Object.assign({}, opts, {
+      params: Object.assign({}, opts.params)
+    });
+    params.Key = opts.key;
+    params.Bucket = opts.params.Bucket || this.bucket;
+  }
+  this.s3.deleteObject(params, done);
   return this;
 };
 


### PR DESCRIPTION
Actually, only the key is used in the remove method.
But we could specify other options, like the Bucket where the object is store.

This PR will use the `params` property if it exist in the `opts` parameter of the `remove` method, like it's already done in others method of the blob store.

What do you think about it ?